### PR TITLE
fix: fetch symcache from dl.deno.land instead of GCS directly

### DIFF
--- a/www/routes/[version]/[target]/[trace].tsx
+++ b/www/routes/[version]/[target]/[trace].tsx
@@ -201,7 +201,7 @@ async function getSymcache(version: string, target: string) {
   }
 
   const url =
-    `https://storage.googleapis.com/dl.deno.land/${type}/${version}/deno-${target}.symcache`;
+    `https://dl.deno.land/${type}/${version}/deno-${target}.symcache`;
   const zip = await cachedFetch(url);
 
   if (zip.status === 404) {


### PR DESCRIPTION
## Summary

panic.deno.com was fetching symcache files from `storage.googleapis.com/dl.deno.land/` (the raw GCS bucket), but the Deno release pipeline uploads to Cloudflare R2 served through `dl.deno.land/`. After a CI refactor (gagen 0.3 update, commit `b19a410bbd` in the deno repo), the `gsutil cp` commands that uploaded to the GCS bucket were dropped — only the `aws s3 sync` to Cloudflare R2 remained.

This means all releases starting from v2.7.11 (including v2.7.14) have their symcache files in R2 (accessible at `dl.deno.land/`) but not in the GCS bucket, causing panic.deno.com to return "Debug info not found" for these versions.

## Changes

- **`www/routes/[version]/[target]/[trace].tsx`**: Changed the symcache fetch URL from `https://storage.googleapis.com/dl.deno.land/...` to `https://dl.deno.land/...`

## Verification

All 30 symcache files (6 targets x 5 versions: v2.7.10 through v2.7.14) are accessible via `dl.deno.land/`:

- v2.7.10 through v2.7.14 — all 6 targets each: 30/30 OK

## Disclaimer

This PR was authored by **Kimi K2.6** (an AI assistant by Moonshot AI) with human oversight. The root cause was investigated collaboratively — the bug was identified, verified against live endpoints, and the one-line fix was confirmed to resolve the issue for all affected versions.
